### PR TITLE
Add virtual destructor in GtirbBuilder

### DIFF
--- a/src/gtirb-builder/GtirbBuilder.h
+++ b/src/gtirb-builder/GtirbBuilder.h
@@ -36,6 +36,7 @@ class GtirbBuilder
 {
 public:
     GtirbBuilder(std::string Path, std::shared_ptr<LIEF::Binary> Binary);
+    virtual ~GtirbBuilder() = default;
 
     struct GTIRB
     {


### PR DESCRIPTION
hi :) while reading through the code I just noticed that `GtirbBuilder` is currently missing a virtual destructor which could lead to undefined behaviour if a sub-class would be deleted polymorphically. Even though the current code does not seem to contain any polymorphic deletions of `GtirbBuilder` it probably doesn't hurt to have the virtual destructor to avoid potential trouble :)