### PR TITLE
Add MOVZ+MOVK address symbolization for ARM64 (non-PIE)

### DIFF
--- a/examples/arm64_asm_examples/ex_movz_movk/Makefile
+++ b/examples/arm64_asm_examples/ex_movz_movk/Makefile
@@ -7,7 +7,7 @@ TARGETS=ex out.txt
 all: out.txt
 check: out.txt
 ex: src.s
-	$(CC) -no-pie $^ -o $@ -static
+	$(CC) -no-pie $^ -o $@
 out.txt: ex
 	$(EXEC) $^ > $@
 clean:

--- a/examples/arm64_asm_examples/ex_movz_movk/Makefile
+++ b/examples/arm64_asm_examples/ex_movz_movk/Makefile
@@ -1,0 +1,14 @@
+CC=aarch64-linux-gnu-gcc
+EXEC=qemu-aarch64 -L /usr/aarch64-linux-gnu
+
+TARGETS=ex out.txt
+
+.PHONY: all clean check
+all: out.txt
+check: out.txt
+ex: src.s
+	$(CC) -no-pie $^ -o $@ -static
+out.txt: ex
+	$(EXEC) $^ > $@
+clean:
+	rm -f $(TARGETS) *.gtirb

--- a/examples/arm64_asm_examples/ex_movz_movk/src.s
+++ b/examples/arm64_asm_examples/ex_movz_movk/src.s
@@ -1,0 +1,38 @@
+// Test: MOVZ+MOVK address construction in non-PIE ARM64 binaries.
+//
+// This exercises the movz_movk_pair Datalog rules.  In a non-PIE executable
+// the linker fills absolute addresses into the MOVZ/MOVK immediates, so
+// ddisasm must recognise the pair as constructing an address and emit
+// symbolic operand candidates with G0/G1 attributes.
+//
+// Expected behaviour after the fix:
+//   - ddisasm produces SymAddrConst for both the MOVZ and the MOVK
+//   - gtirb-pprinter emits:
+//       movz  x0, #:abs_g1:msg
+//       movk  x0, #:abs_g0_nc:msg
+//   - reassembled binary runs identically.
+
+.arch armv8-a
+.file "src.s"
+
+.text
+.global main
+.type main, %function
+
+main:
+    stp     fp, lr, [sp, #-16]!
+
+    // Construct the address of msg using MOVZ + MOVK.
+    // The linker/assembler resolves the relocations at link time.
+    movz    x0, #:abs_g1:msg
+    movk    x0, #:abs_g0_nc:msg
+
+    bl      printf
+
+    mov     x0, #0
+    ldp     fp, lr, [sp], #16
+    ret
+
+.section .rodata
+msg:
+    .asciz "Hello from MOVZ+MOVK!\n"

--- a/examples/arm64_asm_examples/ex_movz_movk/src.s
+++ b/examples/arm64_asm_examples/ex_movz_movk/src.s
@@ -1,11 +1,11 @@
 // Test: MOVZ+MOVK address construction in non-PIE ARM64 binaries.
 //
-// This exercises the movz_movk_pair Datalog rules.  In a non-PIE executable
+// This exercises the movz_movk_chain Datalog rules.  In a non-PIE executable
 // the linker fills absolute addresses into the MOVZ/MOVK immediates, so
-// ddisasm must recognise the pair as constructing an address and emit
+// ddisasm must recognize the pair as constructing an address and emit
 // symbolic operand candidates with G0/G1 attributes.
 //
-// Expected behaviour after the fix:
+// Expected behavior:
 //   - ddisasm produces SymAddrConst for both the MOVZ and the MOVK
 //   - gtirb-pprinter emits:
 //       movz  x0, #:abs_g1:msg

--- a/src/datalog/arch/arm64_symbolization.dl
+++ b/src/datalog/arch/arm64_symbolization.dl
@@ -336,21 +336,17 @@ Individual MOVZ or MOVK instruction with its 16-bit immediate and shift.
 */
 .decl movz_movk_insn(EA:address, Reg:register, Val:number, Shift:unsigned, Operation:symbol)
 
-// MOVZ/MOVK with an explicit lsl #N (N > 0).
 movz_movk_insn(EA, Reg, Imm band 65535, Shift, Operation):-
-    instruction(EA,_,_,Operation,ImmOp,RegOp,0,0,_,_),
+    instruction_get_operation(EA, Operation),
     (Operation = "MOVZ" ; Operation = "MOVK"),
-    op_immediate(ImmOp, Imm, _),
-    op_regdirect_contains_reg(RegOp, Reg),
-    op_shifted(EA, 1, Shift, "LSL").
-
-// MOVZ/MOVK without an explicit shift (lsl #0).
-movz_movk_insn(EA, Reg, Imm band 65535, 0, Operation):-
-    instruction(EA,_,_,Operation,ImmOp,RegOp,0,0,_,_),
-    (Operation = "MOVZ" ; Operation = "MOVK"),
-    op_immediate(ImmOp, Imm, _),
-    op_regdirect_contains_reg(RegOp, Reg),
-    !op_shifted(EA, 1, _, _).
+    arch.move_reg_imm(EA, Reg, Imm, _),
+    (
+        op_shifted(EA, 1, Shift, "LSL")
+        ;
+        Shift = 0,
+        !op_shifted(EA, 1, _, _)
+    ),
+    Shift % 16 = 0.
 
 /**
 A chain of MOVZ followed by one or more MOVKs to the same register.
@@ -402,17 +398,18 @@ This is the one we use for symbolization.
 .decl movz_movk_complete(EA_first:address, EA_last:address, Value:number)
 
 movz_movk_complete(EA_first, EA_last, Value):-
-    movz_movk_chain(EA_first, EA_last, _, Value, _),
+    movz_movk_chain(EA_first, EA_last, Reg, Value, _),
     // This chain cannot be extended by another MOVK.
     (
-        !next(EA_last, _)
+        !next(EA_last, _),
+        UNUSED(Reg)
         ;
         next(EA_last, EA_after),
-        !movz_movk_insn(EA_after, _, _, _, "MOVK")
+        !movz_movk_insn(EA_after, _, _, _, "MOVK"),
+        UNUSED(Reg)
         ;
         next(EA_last, EA_after),
         movz_movk_insn(EA_after, Reg2, _, _, "MOVK"),
-        movz_movk_chain(EA_first, EA_last, Reg, _, _),
         Reg2 != Reg
     ).
 
@@ -463,7 +460,11 @@ symbolic_operand_candidate(EA, 1, Dest, Type):-
     movz_movk_insn(EA, _, _, Shift, _),
     movz_movk_shift_group(Shift, Group).
 
-// Suppress unpaired MOVZ/MOVK from being independently symbolized.
+may_have_symbolic_immediate(EA, as(Value, address)):-
+    movz_movk_complete(EA_first, EA_last, Value),
+    movz_movk_member(EA, EA_first, EA_last).
+
+// Immediate in movz or movk may not be symbolic unless the instruction is part of movz_movk_chain.
 unlikely_have_symbolic_immediate(EA):-
     instruction_get_operation(EA, Operation),
     (Operation = "MOVZ" ; Operation = "MOVK"),

--- a/src/datalog/arch/arm64_symbolization.dl
+++ b/src/datalog/arch/arm64_symbolization.dl
@@ -313,3 +313,158 @@ unlikely_have_symbolic_immediate(EA):-
     instruction_get_operation(EA, Operation),
     contains("ADD", Operation),
     !split_load(_,EA,_,"ADD").
+
+// ===================================================================
+// MOVZ + MOVK address construction
+// ===================================================================
+//
+// In non-PIE ARM64 binaries, absolute addresses are commonly constructed
+// using a MOVZ+MOVK instruction sequence:
+//
+//   movz x0, #0x0, lsl #16     ; x0 = 0x00000000
+//   movk x0, #0x4170            ; x0 = 0x00004170  (address of some symbol)
+//
+// Each instruction sets a 16-bit slice of the register. The shift amount
+// (lsl #0, #16, #32, #48) determines which slice. MOVZ zeros the register
+// first; subsequent MOVKs insert their slice without disturbing others.
+//
+// This is analogous to ARM32's MOVW+MOVT (see arm32_binaries.dl).
+// ===================================================================
+
+/**
+Individual MOVZ or MOVK instruction with its 16-bit immediate and shift.
+*/
+.decl movz_movk_insn(EA:address, Reg:register, Val:number, Shift:unsigned, Operation:symbol)
+
+// MOVZ/MOVK with an explicit lsl #N (N > 0).
+movz_movk_insn(EA, Reg, Imm band 65535, Shift, Operation):-
+    instruction(EA,_,_,Operation,ImmOp,RegOp,0,0,_,_),
+    (Operation = "MOVZ" ; Operation = "MOVK"),
+    op_immediate(ImmOp, Imm, _),
+    op_regdirect_contains_reg(RegOp, Reg),
+    op_shifted(EA, 1, Shift, "LSL").
+
+// MOVZ/MOVK without an explicit shift (lsl #0).
+movz_movk_insn(EA, Reg, Imm band 65535, 0, Operation):-
+    instruction(EA,_,_,Operation,ImmOp,RegOp,0,0,_,_),
+    (Operation = "MOVZ" ; Operation = "MOVK"),
+    op_immediate(ImmOp, Imm, _),
+    op_regdirect_contains_reg(RegOp, Reg),
+    !op_shifted(EA, 1, _, _).
+
+/**
+A chain of MOVZ followed by one or more MOVKs to the same register.
+EA_first is always the MOVZ; EA_last is the last instruction added.
+Value is the accumulated composite from all instructions in the chain.
+Count tracks the number of instructions in the chain (2-4).
+*/
+.decl movz_movk_chain(EA_first:address, EA_last:address, Reg:register, Value:number, Count:unsigned)
+
+// Base case: MOVZ followed immediately by a MOVK to the same register.
+movz_movk_chain(EA_movz, EA_movk, Reg, Value, 2):-
+    movz_movk_insn(EA_movz, Reg, Val_z, Shift_z, "MOVZ"),
+    next(EA_movz, EA_movk),
+    movz_movk_insn(EA_movk, Reg, Val_k, Shift_k, "MOVK"),
+    Shift_z != Shift_k,
+    Value = (Val_z * 2^as(Shift_z, number)) bor (Val_k * 2^as(Shift_k, number)).
+
+// Chain of 3: MOVZ + MOVK + MOVK, each with a unique shift.
+movz_movk_chain(EA_first, EA3, Reg, NewValue, 3):-
+    movz_movk_chain(EA_first, EA2, Reg, Value, 2),
+    next(EA2, EA3),
+    movz_movk_insn(EA3, Reg, Val_3, Shift_3, "MOVK"),
+    // Shift_3 must differ from both earlier shifts.
+    movz_movk_insn(EA_first, _, _, Shift_first, _),
+    movz_movk_insn(EA2, _, _, Shift_2, _),
+    Shift_3 != Shift_first,
+    Shift_3 != Shift_2,
+    NewValue = Value bor (Val_3 * 2^as(Shift_3, number)).
+
+// Chain of 4: MOVZ + 3 MOVKs, each with a unique shift.
+movz_movk_chain(EA_first, EA4, Reg, NewValue, 4):-
+    movz_movk_chain(EA_first, EA3, Reg, Value, 3),
+    next(EA3, EA4),
+    movz_movk_insn(EA4, Reg, Val_4, Shift_4, "MOVK"),
+    // Shift_4 must differ from all three earlier shifts.
+    movz_movk_insn(EA_first, _, _, Shift_first, _),
+    movz_movk_chain(EA_first, EA2, _, _, 2),
+    movz_movk_insn(EA2, _, _, Shift_2, _),
+    movz_movk_insn(EA3, _, _, Shift_3, _),
+    Shift_4 != Shift_first,
+    Shift_4 != Shift_2,
+    Shift_4 != Shift_3,
+    NewValue = Value bor (Val_4 * 2^as(Shift_4, number)).
+
+/**
+The longest complete MOVZ+MOVK chain: a chain that cannot be extended further.
+This is the one we use for symbolization.
+*/
+.decl movz_movk_complete(EA_first:address, EA_last:address, Value:number)
+
+movz_movk_complete(EA_first, EA_last, Value):-
+    movz_movk_chain(EA_first, EA_last, _, Value, _),
+    // This chain cannot be extended by another MOVK.
+    (
+        !next(EA_last, _)
+        ;
+        next(EA_last, EA_after),
+        !movz_movk_insn(EA_after, _, _, _, "MOVK")
+        ;
+        next(EA_last, EA_after),
+        movz_movk_insn(EA_after, Reg2, _, _, "MOVK"),
+        movz_movk_chain(EA_first, EA_last, Reg, _, _),
+        Reg2 != Reg
+    ).
+
+/**
+Helper: is EA part of a complete MOVZ+MOVK chain?
+*/
+.decl movz_movk_member(EA:address, EA_first:address, EA_last:address)
+
+// The MOVZ itself.
+movz_movk_member(EA_first, EA_first, EA_last):-
+    movz_movk_complete(EA_first, EA_last, _).
+
+// Each MOVK in the chain.
+movz_movk_member(EA, EA_first, EA_last):-
+    movz_movk_complete(EA_first, EA_last, _),
+    movz_movk_chain(EA_first, EA, _, _, _),
+    EA != EA_first.
+
+/**
+Helper: map a shift amount to the corresponding group attribute name.
+*/
+.decl movz_movk_shift_group(Shift:unsigned, Group:symbol)
+
+movz_movk_shift_group(0,  "G0").
+movz_movk_shift_group(16, "G1").
+movz_movk_shift_group(32, "G2").
+movz_movk_shift_group(48, "G3").
+
+/**
+For non-PIE (EXEC) binaries, generate symbolic operand candidates
+when a complete MOVZ+MOVK chain constructs a value that matches a known
+code or data address. Each instruction gets a G0-G3 attribute
+indicating which 16-bit group it contributes.
+*/
+symbolic_operand_attribute(EA, 1, Group),
+symbolic_operand_candidate(EA, 1, Dest, Type):-
+    binary_type("EXEC"),
+    movz_movk_complete(EA_first, EA_last, Value),
+    Dest = as(Value, address),
+    (
+        code(Dest), Type = "code"
+        ;
+        data_segment(Begin, End),
+        Dest >= Begin, Dest <= End,
+        Type = "data"
+    ),
+    movz_movk_member(EA, EA_first, EA_last),
+    movz_movk_insn(EA, _, _, Shift, _),
+    movz_movk_shift_group(Shift, Group).
+
+// Suppress unpaired MOVZ/MOVK from being independently symbolized.
+unlikely_have_symbolic_immediate(EA):-
+    instruction_get_operation(EA, Operation),
+    (Operation = "MOVZ" ; Operation = "MOVK"),
+    !movz_movk_member(EA, _, _).

--- a/src/gtirb-decoder/arch/Arm64Loader.cpp
+++ b/src/gtirb-decoder/arch/Arm64Loader.cpp
@@ -92,17 +92,14 @@ bool Arm64Loader::build(BinaryFacts& Facts, const cs_insn& CsInstruction)
         for(uint8_t i = 0; i < OpCount; i++)
         {
             // Load capstone operand.
+            cs_arm64_op CsOp = Details.operands[i];
             // For aliased MOVZ, we fix up the immediate operand to recover the
             // original 16-bit value and shift that capstone folded away.
-            cs_arm64_op CsOp = Details.operands[i];
-            if(IsAliasedMovz && CsOp.type == ARM64_OP_IMM)
+            if(IsAliasedMovz && CsOp.type == ARM64_OP_IMM && AliasedShift > 0)
             {
                 CsOp.imm = AliasedImm16;
-                if(AliasedShift > 0)
-                {
-                    CsOp.shift.type = ARM64_SFT_LSL;
-                    CsOp.shift.value = AliasedShift;
-                }
+                CsOp.shift.type = ARM64_SFT_LSL;
+                CsOp.shift.value = AliasedShift;
             }
 
             // Build operand for datalog fact.

--- a/src/gtirb-decoder/arch/Arm64Loader.cpp
+++ b/src/gtirb-decoder/arch/Arm64Loader.cpp
@@ -78,6 +78,17 @@ bool Arm64Loader::build(BinaryFacts& Facts, const cs_insn& CsInstruction)
             uint64_t OpIndex = Facts.Operands.add(*Op);
             OpCodes.push_back(OpIndex);
 
+            // Populate shift metadata for immediate operands (e.g., MOVZ/MOVK
+            // with lsl #16/#32/#48). This is needed for MOVZ+MOVK address
+            // reconstruction in the Datalog symbolization rules.
+            if(CsOp.type == ARM64_OP_IMM && CsOp.shift.type == ARM64_SFT_LSL
+               && CsOp.shift.value != 0)
+            {
+                Facts.Instructions.shiftedOp(
+                    relations::ShiftedOp{Addr, rotated_op_index(i + 1, OpCount),
+                                         static_cast<uint8_t>(CsOp.shift.value), "LSL"});
+            }
+
             // Populate shift metadata if present.
             if(CsOp.type == ARM64_OP_REG && CsOp.shift.value != 0)
             {

--- a/src/gtirb-decoder/arch/Arm64Loader.cpp
+++ b/src/gtirb-decoder/arch/Arm64Loader.cpp
@@ -59,13 +59,51 @@ bool Arm64Loader::build(BinaryFacts& Facts, const cs_insn& CsInstruction)
     gtirb::Addr Addr(CsInstruction.address);
     std::vector<uint64_t> OpCodes;
 
+    // Capstone aliases MOVZ as MOV when imm16 != 0 (ARM preferred disassembly),
+    // folding the shift into the immediate (e.g., "MOVZ X0, #0x40, LSL #16"
+    // becomes "MOV X0, #0x400000") and using ARM64_INS_MOV as the instruction
+    // id. Detect the MOVZ encoding from raw instruction bytes and recover the
+    // canonical form so the Datalog MOVZ+MOVK symbolization rules can match.
+    bool IsAliasedMovz = false;
+    unsigned AliasedShift = 0;
+    int64_t AliasedImm16 = 0;
+    if(Name == "MOV" && CsInstruction.size == 4)
+    {
+        uint32_t Enc = static_cast<uint32_t>(CsInstruction.bytes[0])
+                       | (static_cast<uint32_t>(CsInstruction.bytes[1]) << 8)
+                       | (static_cast<uint32_t>(CsInstruction.bytes[2]) << 16)
+                       | (static_cast<uint32_t>(CsInstruction.bytes[3]) << 24);
+        // MOVZ encoding: sf[31] opc[30:29]=10 100101[28:23] hw[22:21] imm16[20:5] rd[4:0]
+        bool IsMovzEncoding = ((Enc >> 23) & 0x3F) == 0x25   // bits [28:23] = 100101
+                              && ((Enc >> 29) & 0x3) == 0x2;  // opc = 10 (MOVZ)
+        if(IsMovzEncoding)
+        {
+            unsigned Hw = (Enc >> 21) & 0x3;
+            AliasedShift = Hw * 16;
+            AliasedImm16 = static_cast<int64_t>((Enc >> 5) & 0xFFFF);
+            IsAliasedMovz = true;
+            Name = "MOVZ";
+        }
+    }
+
     if(Name != "NOP")
     {
         uint8_t OpCount = Details.op_count;
         for(uint8_t i = 0; i < OpCount; i++)
         {
             // Load capstone operand.
-            const cs_arm64_op& CsOp = Details.operands[i];
+            // For aliased MOVZ, we fix up the immediate operand to recover the
+            // original 16-bit value and shift that capstone folded away.
+            cs_arm64_op CsOp = Details.operands[i];
+            if(IsAliasedMovz && CsOp.type == ARM64_OP_IMM)
+            {
+                CsOp.imm = AliasedImm16;
+                if(AliasedShift > 0)
+                {
+                    CsOp.shift.type = ARM64_SFT_LSL;
+                    CsOp.shift.value = AliasedShift;
+                }
+            }
 
             // Build operand for datalog fact.
             std::optional<relations::Operand> Op = build(CsInstruction, i, CsOp);

--- a/src/passes/Disassembler.cpp
+++ b/src/passes/Disassembler.cpp
@@ -538,6 +538,8 @@ gtirb::SymAttributeSet buildSymbolicExpressionAttributes(
         // ARM
         {"G0", gtirb::SymAttribute::G0},
         {"G1", gtirb::SymAttribute::G1},
+        {"G2", gtirb::SymAttribute::G2},
+        {"G3", gtirb::SymAttribute::G3},
         {"LO12", gtirb::SymAttribute::LO12},
         // MIPS
         {"HI", gtirb::SymAttribute::HI},

--- a/tests/qemu-elf-arm64.yaml
+++ b/tests/qemu-elf-arm64.yaml
@@ -176,6 +176,9 @@ tests:
   - name: ex_post_index_no_lo12
     <<: *assembly
 
+  - name: ex_movz_movk
+    <<: *assembly
+
   # ex1, stripped, dynamic
   - name: ex1
     <<: *default


### PR DESCRIPTION
Add MOVZ+MOVK address symbolization for ARM64 (non-PIE)


Fixes #90